### PR TITLE
Minor updates; make 0 warnings

### DIFF
--- a/MemoryDumpTo/CreateTableText.cpp
+++ b/MemoryDumpTo/CreateTableText.cpp
@@ -1,5 +1,5 @@
 
-#include <MemoryDumpTo.h>
+#include "MemoryDumpTo.h"
 
 #define szHeaderDELPHI   "const Table: array[0..%u] of %s = (\r\n"
 #define szHeaderCPP      "const %s Table[%u] = {\r\n"

--- a/MemoryDumpTo/MemoryDumpTo.cpp
+++ b/MemoryDumpTo/MemoryDumpTo.cpp
@@ -1,5 +1,5 @@
 
-#include <MemoryDumpTo.h>
+#include "MemoryDumpTo.h"
 
 // GLOBAL Plugin SDK variables
 int pluginHandle;
@@ -10,7 +10,7 @@ int hMenuDisasm;
 int hMenuDump;
 int hMenuStack;
 
-extern "C" DLL_EXPORT BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+extern "C" BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     hInstDLL = hinstDLL;
     return TRUE;
@@ -18,11 +18,8 @@ extern "C" DLL_EXPORT BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason,
 
 BOOL AboutDlg()
 {
-    MSGBOXPARAMS mbp;
-    TCHAR Buffer[MAX_PATH / 2];
-
-    __stosb((PBYTE)&mbp, 0, sizeof(mbp));
-    __stosb((PBYTE)&Buffer, 0, sizeof(Buffer));
+    MSGBOXPARAMS mbp{};
+    TCHAR Buffer[MAX_PATH / 2]{};
 
     mbp.cbSize = sizeof(mbp);
     mbp.hwndOwner = hwndDlg;
@@ -32,11 +29,9 @@ BOOL AboutDlg()
     mbp.dwStyle = MB_OK | MB_USERICON;
     mbp.lpszIcon = MAKEINTRESOURCE(IDI_ICON);
 
-
     wsprintf(Buffer, szMemoryDumpToAbout, sz_plugin_version);
     MessageBoxIndirect(&mbp);
 
-    //MessageBox(hwndDlg, Buffer, TEXT("About"), MB_ICONINFORMATION);
     return TRUE;
 }
 

--- a/MemoryDumpTo/MemoryDumpTo.h
+++ b/MemoryDumpTo/MemoryDumpTo.h
@@ -29,7 +29,7 @@ extern int hMenuStack;
 #define szMemoryDumpToAbout (szMemoryDumpTo TEXT(" \n") szCopyright)
 #define plugin_name "MemoryDumpTo"
 #define plugin_version 1
-#define sz_plugin_version TEXT("0.2")
+#define sz_plugin_version TEXT("0.3")
 
 #define lengthof(s) { sizeof(s) / sizeof((s)[0]) }
 

--- a/MemoryDumpTo/MemoryDumpTo.vcxproj
+++ b/MemoryDumpTo/MemoryDumpTo.vcxproj
@@ -103,7 +103,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <ErrorReporting>None</ErrorReporting>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <ExceptionHandling>false</ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <StringPooling>true</StringPooling>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <GuardEHContMetadata>false</GuardEHContMetadata>
@@ -136,7 +136,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <OmitFramePointers>false</OmitFramePointers>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <ExceptionHandling>false</ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <StringPooling>true</StringPooling>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <GuardEHContMetadata>false</GuardEHContMetadata>
@@ -170,7 +170,7 @@
       <ErrorReporting>None</ErrorReporting>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
-      <ExceptionHandling>false</ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <StringPooling>true</StringPooling>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <GuardEHContMetadata>false</GuardEHContMetadata>
@@ -206,7 +206,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
-      <ExceptionHandling>false</ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <StringPooling>true</StringPooling>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <GuardEHContMetadata>false</GuardEHContMetadata>


### PR DESCRIPTION
hello friend! 
long time no see
now I know here is your GH home :)

so some notes on the changes:

1) <> are for system headers only, so lets ease it:

#include <MemoryDumpTo.h>
->
#include "MemoryDumpTo.h"

2) let compiler do the dirty job:

 __stosb
->
{}

This is the cleanest and most portable way. It tells the compiler to zero-initialize the entire structure or array.

3) make 0 warnings!

before

```

1>MemoryDumpTo.cpp
1>C:\Dev\VS2019\VC\Tools\MSVC\14.29.30133\include\vector(1296,1): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
1>C:\Dev\VS2019\VC\Tools\MSVC\14.29.30133\include\vector(1286): message : while compiling class template member function 'void std::vector<BridgeCFNodeList,std::allocator<BridgeCFNodeList>>::_Reallocate_exactly(const unsigned __int64)'
1>C:\Dev\VS2019\VC\Tools\MSVC\14.29.30133\include\vector(1363): message : see reference to function template instantiation 'void std::vector<BridgeCFNodeList,std::allocator<BridgeCFNodeList>>::_Reallocate_exactly(const unsigned __int64)' being compiled

```

after

```
Rebuild started...
1>------ Rebuild All started: Project: MemoryDumpTo, Configuration: Debug x64 ------
1>CreateTableText.cpp
1>MemoryDumpTo.cpp
1>plugin.cpp
1>Generating Code...
1>   Creating library C:\Prg\MemoryDumpTo\x64\Debug\MemoryDumpTo.lib and object C:\Prg\MemoryDumpTo\x64\Debug\MemoryDumpTo.exp
1>MemoryDumpTo.vcxproj -> C:\Prg\MemoryDumpTo\x64\Debug\MemoryDumpTo.dp64
========== Rebuild All: 1 succeeded, 0 failed, 0 skipped ==========

```

Note: added Exception handling support as the dependent libs are using std::vector/etc -> which are in need of exceptions support...

4)

DllMain:
An entry point was exported from a DLL. The entry point of a DLL does not need to be exported.


->
removed export directive

